### PR TITLE
Fix the :delete command

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ var cc = "clang"  # C compiler to use for execution
 
 Compile the source:
 ```
-nim -d:release --rangeChecks:on c nrpl.nim
+nim -d:release c nrpl.nim
 ```
 Sample execution:
 ```

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ var cc = "clang"  # C compiler to use for execution
 
 Compile the source:
 ```
-nim -d:release c nrpl.nim
+nim -d:release --rangeChecks:on c nrpl.nim
 ```
 Sample execution:
 ```

--- a/nrpl.nim
+++ b/nrpl.nim
@@ -164,8 +164,8 @@ while(true):
   var lines = join(prefixLines, "\n")
   writeFile("nrpltmp.nim", lines)
   try:
-    let res = execShellCmd("nim --cc:" & cc & " --verbosity:0 -d:release -r c nrpltmp.nim")
-    if res != 0 or line.contains("echo"):
+    discard execShellCmd("nim --cc:" & cc & " --verbosity:0 -d:release -r c nrpltmp.nim")
+    if line.contains("echo"):
       discard prefixLines.pop()
   except:
     break

--- a/nrpl.nim
+++ b/nrpl.nim
@@ -164,8 +164,8 @@ while(true):
   var lines = join(prefixLines, "\n")
   writeFile("nrpltmp.nim", lines)
   try:
-    discard execShellCmd("nim --cc:" & cc & " --verbosity:0 -d:release -r c nrpltmp.nim")
-    if line.contains("echo"):
+    let res = execShellCmd("nim --cc:" & cc & " --verbosity:0 -d:release -r c nrpltmp.nim")
+    if res != 0 or line.contains("echo"):
       discard prefixLines.pop()
   except:
     break

--- a/nrpl.nim
+++ b/nrpl.nim
@@ -113,16 +113,29 @@ while(true):
     continue
 
   elif line.startsWith(":delete ") or line.startsWith(":d "):
-    var tokens = line.strip().split(re":d(elete)?\s+")
-    if tokens[0].contains(","):
-      proc myStrip(s: string): string = s.strip()
-      var lineNums = tokens[0].split(",").map(myStrip).map(parseInt)
-      var lineNum = lineNums[0] - 1
-      for x in 0..lineNums.len:
+    proc myStrip(s: string): string = s.strip()
+
+    try:
+      var numbers =
+        line.strip()
+            .replace(re":d(elete)?\s+", "")
+            .split(re"[,\s]+")
+            .map(myStrip)
+            .map(parseInt)
+
+      if numbers.len == 2:
+        var lineNum = numbers[0] - 1
+        for x in numbers[0]..numbers[1]:
+          prefixLines.delete(lineNum)
+      elif numbers.len == 1:
+        var lineNum = numbers[0] - 1
         prefixLines.delete(lineNum)
-    else:
-      var lineNum = parseInt(tokens[0]) - 1
-      prefixLines.delete(lineNum)
+      else:
+        echo "syntax: :delete from[,to]"
+    except RangeError:
+      echo "Invalid line numbers"
+    except ValueError:
+      echo "syntax: :delete from[,to]"
     continue
 
   elif line == ":run" or line == ":r":

--- a/nrpl.nim
+++ b/nrpl.nim
@@ -113,29 +113,16 @@ while(true):
     continue
 
   elif line.startsWith(":delete ") or line.startsWith(":d "):
-    proc myStrip(s: string): string = s.strip()
-
-    try:
-      var numbers =
-        line.strip()
-            .replace(re":d(elete)?\s+", "")
-            .split(re"[,\s]+")
-            .map(myStrip)
-            .map(parseInt)
-
-      if numbers.len == 2:
-        var lineNum = numbers[0] - 1
-        for x in numbers[0]..numbers[1]:
-          prefixLines.delete(lineNum)
-      elif numbers.len == 1:
-        var lineNum = numbers[0] - 1
+    var tokens = line.strip().split(re":d(elete)?\s+")
+    if tokens[0].contains(","):
+      proc myStrip(s: string): string = s.strip()
+      var lineNums = tokens[0].split(",").map(myStrip).map(parseInt)
+      var lineNum = lineNums[0] - 1
+      for x in 0..lineNums.len:
         prefixLines.delete(lineNum)
-      else:
-        echo "syntax: :delete from[,to]"
-    except RangeError:
-      echo "Invalid line numbers"
-    except ValueError:
-      echo "syntax: :delete from[,to]"
+    else:
+      var lineNum = parseInt(tokens[0]) - 1
+      prefixLines.delete(lineNum)
     continue
 
   elif line == ":run" or line == ":r":


### PR DESCRIPTION
The delete command is pretty broken, this fixes it to what I think was intended originally. A side effect of this is the necessity of range checks so now `-rangeChecks:on` is needed.

The atrocious commit history is a result of my careless bungling, but the final result should be fine.