### PR TITLE
Remove the last erroneous command.

### DIFF
--- a/nrpl.nim
+++ b/nrpl.nim
@@ -6,6 +6,7 @@ import os
 import osproc
 import re
 import strutils
+import sequtils
 
 const version = "0.1.4"
 ## var cc = "clang"  # C compiler to use for execution
@@ -195,6 +196,8 @@ while(true):
         if rline.strip().len() > 0:
           stdout.writeln(rline)
     if line.contains("echo"):
+      discard prefixLines.pop()
+    elif result.exitCode != 0:
       discard prefixLines.pop()
   except:
     break

--- a/nrpl.nim
+++ b/nrpl.nim
@@ -86,7 +86,9 @@ while(true):
   else:
     stdout.write("> ")
   stdout.flushFile()
-  var line = stdin.readLine()
+  var line = ""
+  if not stdin.readLine(line):
+    quit()
 
   if line.strip().len() == 0:
     if inBlock:

--- a/nrpl.nim
+++ b/nrpl.nim
@@ -88,7 +88,7 @@ while(true):
   stdout.flushFile()
   var line = ""
   if not stdin.readLine(line):
-    quit()
+    break
 
   if line.strip().len() == 0:
     if inBlock:


### PR DESCRIPTION
For example, here is the log:

```
> let x = 123
> x
nrpltmp.nim(2, 1) Error: value of type 'int' has to be discarded
```

This PR removes `x` line from the history. 

And also it compiles again :-) (checked on the latest devel).
